### PR TITLE
Separate invalid character check into 3 checks

### DIFF
--- a/SlopCrew.Server/ConnectionState.cs
+++ b/SlopCrew.Server/ConnectionState.cs
@@ -94,14 +94,14 @@ public class ConnectionState {
 
     private void HandleHello(ServerboundPlayerHello enter, Server server) {
         // Temporary solution to CharacterAPI players crashing other players
-        var isInvalid = enter.Player.Character is < -1 or > 26
-                        || enter.Player.Outfit is < 0 or > 3
-                        || enter.Player.MoveStyle is < 0 or > 5;
-        if (isInvalid) {
-            enter.Player.Character = 3; // Red
+        if (enter.Player.Character is < 0 or > 25)
+            enter.Player.Character = 3;
+
+        if (enter.Player.Character is < 0 or > 3)
             enter.Player.Outfit = 0;
+
+        if (enter.Player.MoveStyle is < 0 or > 4)
             enter.Player.MoveStyle = 0;
-        }
 
         // Assign a unique ID on first hello
         // Subsequent hellos keep the originally assigned ID


### PR DESCRIPTION
These are now separate checks since otherwise it would cause people using CharacterAPI characters to suddenly be on foot even when they're not. (on foot also has some animation glitches when grinding so forcing it on invalid characters isn't desirable)

Additionally, some of the ranges were adjusted since some can crash the game:
- Character: Range is decreased to 0-25, -1 and 26 crash
- Movestyle: Range is decreased to 0-4, 5 crashes