### PR TITLE
Race enhancement

### DIFF
--- a/SlopCrew.Common/Network/Clientbound/ClientboundEncounterCancel.cs
+++ b/SlopCrew.Common/Network/Clientbound/ClientboundEncounterCancel.cs
@@ -1,0 +1,16 @@
+using System.IO;
+
+namespace SlopCrew.Common.Network.Clientbound {
+    public class ClientboundEncounterCancel : NetworkPacket {
+        public override NetworkMessageType MessageType => NetworkMessageType.ClientboundEncounterCancel;
+        public EncounterType EncounterType;
+
+        public override void Read(BinaryReader br) {
+            this.EncounterType = (EncounterType) br.ReadInt32();
+        }
+
+        public override void Write(BinaryWriter bw) {
+            bw.Write((int) this.EncounterType);
+        }
+    }
+}

--- a/SlopCrew.Common/Network/NetworkMessageType.cs
+++ b/SlopCrew.Common/Network/NetworkMessageType.cs
@@ -1,11 +1,13 @@
 namespace SlopCrew.Common.Network;
 
-public enum NetworkMessageType {
+public enum NetworkMessageType
+{
     // Keep this at zero just in case the others shift
     ServerboundVersion,
 
     ClientboundEncounterEnd,
     ClientboundEncounterRequest,
+    ClientboundEncounterCancel,
     ClientboundEncounterStart,
     ClientboundPlayerAnimation,
     ClientboundPlayerPositionUpdate,
@@ -17,6 +19,7 @@ public enum NetworkMessageType {
 
     ServerboundAnimation,
     ServerboundEncounterRequest,
+    ServerboundEncounterCancel,
     ServerboundPing,
     ServerboundPlayerHello,
     ServerboundPositionUpdate,

--- a/SlopCrew.Common/Network/NetworkPacket.cs
+++ b/SlopCrew.Common/Network/NetworkPacket.cs
@@ -27,6 +27,7 @@ public abstract class NetworkPacket : NetworkSerializable {
             {NetworkMessageType.ClientboundEncounterRequest, () => new ClientboundEncounterRequest()},
             {NetworkMessageType.ClientboundEncounterStart, () => new ClientboundEncounterStart()},
             {NetworkMessageType.ClientboundEncounterEnd, () => new ClientboundEncounterEnd()},
+            {NetworkMessageType.ClientboundEncounterCancel, () => new ClientboundEncounterCancel()},
 
             {NetworkMessageType.ServerboundAnimation, () => new ServerboundAnimation()},
             {NetworkMessageType.ServerboundPing, () => new ServerboundPing()},
@@ -35,7 +36,8 @@ public abstract class NetworkPacket : NetworkSerializable {
             {NetworkMessageType.ServerboundScoreUpdate, () => new ServerboundScoreUpdate()},
             {NetworkMessageType.ServerboundVisualUpdate, () => new ServerboundVisualUpdate()},
             {NetworkMessageType.ServerboundEncounterRequest, () => new ServerboundEncounterRequest()},
-            {NetworkMessageType.ServerboundRaceFinish, () => new ServerboundRaceFinish()}
+            {NetworkMessageType.ServerboundRaceFinish, () => new ServerboundRaceFinish()},
+            {NetworkMessageType.ServerboundEncounterCancel, () => new ServerboundEncounterCancel() }
         };
 
     public static NetworkPacket Read(byte[] data) {

--- a/SlopCrew.Common/Network/Serverbound/ServerboundEncounterCancel.cs
+++ b/SlopCrew.Common/Network/Serverbound/ServerboundEncounterCancel.cs
@@ -1,0 +1,16 @@
+using System.IO;
+
+namespace SlopCrew.Common.Network.Serverbound {
+    public class ServerboundEncounterCancel : NetworkPacket {
+        public override NetworkMessageType MessageType => NetworkMessageType.ServerboundEncounterCancel;
+        public EncounterType EncounterType;
+
+        public override void Read(BinaryReader br) {
+            this.EncounterType = (EncounterType) br.ReadInt32();
+        }
+
+        public override void Write(BinaryWriter bw) {
+            bw.Write((int) this.EncounterType);
+        }
+    }
+}

--- a/SlopCrew.NetworkTests/Program.cs
+++ b/SlopCrew.NetworkTests/Program.cs
@@ -1,9 +1,9 @@
-﻿using System.Collections;
-using System.Numerics;
 using SlopCrew.Common;
 using SlopCrew.Common.Network;
 using SlopCrew.Common.Network.Clientbound;
 using SlopCrew.Common.Network.Serverbound;
+using System.Collections;
+using System.Numerics;
 
 var useEqualsTypes = new List<Type> {
     typeof(string),
@@ -90,6 +90,10 @@ var packets = new List<NetworkPacket> {
         ID = 42069
     },
 
+    new ClientboundEncounterCancel {
+        EncounterType = EncounterType.RaceEncounter
+    },
+
     new ServerboundPing {
         ID = 42069
     },
@@ -130,7 +134,11 @@ var packets = new List<NetworkPacket> {
     new ServerboundEncounterRequest {
         PlayerID = 42069,
         EncounterType = EncounterType.ScoreEncounter
-    }
+    },
+
+    new ServerboundEncounterCancel {
+        EncounterType = EncounterType.RaceEncounter
+    },
 };
 
 foreach (var packet in packets) {

--- a/SlopCrew.Plugin/PlayerManager.cs
+++ b/SlopCrew.Plugin/PlayerManager.cs
@@ -1,6 +1,8 @@
 using HarmonyLib;
+using MonoMod.Utils;
 using Reptile;
 using SlopCrew.Common;
+using SlopCrew.Common.Encounters;
 using SlopCrew.Common.Network;
 using SlopCrew.Common.Network.Clientbound;
 using SlopCrew.Common.Network.Serverbound;
@@ -8,8 +10,6 @@ using SlopCrew.Plugin.Encounters;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using MonoMod.Utils;
-using SlopCrew.Common.Encounters;
 using Player = Reptile.Player;
 using Vector3 = System.Numerics.Vector3;
 
@@ -260,6 +260,16 @@ public class PlayerManager : IDisposable {
         };
     }
 
+    private void HandleEncounterCancel(ClientboundEncounterCancel encounterCancel) {
+        if (Plugin.HasEncounterBeenCancelled) return;
+
+        switch (encounterCancel.EncounterType) {
+            case EncounterType.RaceEncounter:
+                Plugin.HasEncounterBeenCancelled = true;
+                break;
+        }
+    }
+
     private void HandleEncounterRequest(ClientboundEncounterRequest encounterRequest) {
         Plugin.PhoneInitializer.ShowNotif(encounterRequest);
     }
@@ -306,6 +316,10 @@ public class PlayerManager : IDisposable {
 
             case ClientboundEncounterEnd encounterEnd:
                 this.HandleEncounterEnd(encounterEnd);
+                break;
+
+            case ClientboundEncounterCancel encounterCancel:
+                this.HandleEncounterCancel(encounterCancel);
                 break;
         }
     }

--- a/SlopCrew.Plugin/Plugin.cs
+++ b/SlopCrew.Plugin/Plugin.cs
@@ -1,4 +1,4 @@
-﻿using BepInEx;
+using BepInEx;
 using BepInEx.Logging;
 using HarmonyLib;
 using SlopCrew.API;
@@ -23,6 +23,7 @@ public class Plugin : BaseUnityPlugin {
     public static PlayerManager PlayerManager = null!;
     public static SlopCrewAPI API = null!;
     public static SlopEncounter? CurrentEncounter;
+    public static bool HasEncounterBeenCancelled = false;
     public static PhoneInitializer PhoneInitializer = null!;
 
     private static int ShouldIgnoreInputInternal = 0;
@@ -58,7 +59,7 @@ public class Plugin : BaseUnityPlugin {
     }
 
     private void Update() {
-        if (CurrentEncounter is {IsBusy: false}) {
+        if (CurrentEncounter is { IsBusy: false }) {
             CurrentEncounter.Dispose();
             CurrentEncounter = null;
         }

--- a/SlopCrew.Server/Encounters/RaceStatefulEncounter.cs
+++ b/SlopCrew.Server/Encounters/RaceStatefulEncounter.cs
@@ -1,8 +1,6 @@
-using Serilog;
 using SlopCrew.Common;
-using SlopCrew.Common.Network;
-using SlopCrew.Common.Network.Clientbound;
 using SlopCrew.Common.Encounters;
+using SlopCrew.Common.Network.Clientbound;
 
 namespace SlopCrew.Server.Race;
 
@@ -18,6 +16,7 @@ public class RaceStatefulEncounter : StatefulEncounter {
         var random = new Random();
         var index = random.Next(0, pool.Count);
         this.ConfigData = pool[index];
+        this.EncounterType = EncounterType.RaceEncounter;
     }
 
     public const int MaxRaceTime = 600;


### PR DESCRIPTION
Mostly:

- Add the ability to manually dequeue from a race before it start
- Freeze the slop crew app until either the race start or manually cancelled to prevent being able to start combo/score encounter with another player while being in a race queue
- Updated race tick to work per stage instead of being globally (this is purely questionable, the main reason i did this is to have race ticks being independant from the others
