### PR TITLE
Add configurable dark outline to nameplates for better contrast

### DIFF
--- a/SlopCrew.Plugin/SlopConfigFile.cs
+++ b/SlopCrew.Plugin/SlopConfigFile.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using BepInEx.Configuration;
 
 namespace SlopCrew.Plugin;
@@ -15,6 +15,7 @@ public class SlopConfigFile {
     public ConfigEntry<bool> ShowConnectionInfo;
     public ConfigEntry<bool> ShowPlayerNameplates;
     public ConfigEntry<bool> BillboardNameplates;
+    public ConfigEntry<bool> OutlineNameplates;
     public ConfigEntry<bool> ShowPlayerMapPins;
 
     // Phone
@@ -81,6 +82,13 @@ public class SlopConfigFile {
             "BillboardNameplates",
             true,
             "Billboard nameplates (always face the camera)."
+        );
+
+        this.OutlineNameplates = this.config.Bind(
+            "General",
+            "OutlineNameplates",
+            true,
+            "Add a dark outline to nameplates for contrast."
         );
 
         this.ShowPlayerMapPins = this.config.Bind(

--- a/SlopCrew.Plugin/UI/Phone/AppSlopCrew.cs
+++ b/SlopCrew.Plugin/UI/Phone/AppSlopCrew.cs
@@ -366,8 +366,6 @@ public class AppSlopCrew : App {
         if (player == null) {
             if (this.playerLocked) this.playerLocked = false;
             SetStatusText("NEAREST PLAYER", "None found.");
-
-
             return;
         }
 


### PR DESCRIPTION
Example:
![image](https://github.com/SlopCrew/SlopCrew/assets/50772474/f6fdfc5f-e0af-4316-8557-59fca42e0089)