### PR TITLE
Fix status label for new buttons blending in

### DIFF
--- a/SlopCrew.Plugin/UI/Phone/SlopCrewButton.cs
+++ b/SlopCrew.Plugin/UI/Phone/SlopCrewButton.cs
@@ -94,7 +94,7 @@ internal class SlopCrewButton : PhoneScrollButton {
         this.buttonBackground!.sprite = selectedButtonSprite;
         this.modeLabel!.color = selectedModeColor;
         this.descriptionLabel!.color = selectedModeColor;
-        this.statusLabel!.color = selectedModeColor;
+        this.statusLabel!.color = normalModeColor;
         this.confirmArrow!.SetActive(true);
     }
 
@@ -103,7 +103,7 @@ internal class SlopCrewButton : PhoneScrollButton {
         this.buttonBackground!.sprite = normalButtonSprite;
         this.modeLabel!.color = normalModeColor;
         this.descriptionLabel!.color = normalModeColor;
-        this.statusLabel!.color = normalModeColor;
+        this.statusLabel!.color = selectedModeColor;
         this.confirmArrow!.SetActive(false);
     }
 


### PR DESCRIPTION
This is because with Kuma's sprite sheet, the bar for the status label is set to the inverted colors, meaning we need to swap the selected and normal colors in OnSelect and OnDeselect for the status label.