### PR TITLE
API enhancements for syncing moving platforms across clients

### DIFF
--- a/SlopCrew.API/ISlopCrewAPI.cs
+++ b/SlopCrew.API/ISlopCrewAPI.cs
@@ -13,6 +13,7 @@ public interface ISlopCrewAPI {
     public event Action OnConnected;
     public event Action OnDisconnected;
     public ulong Latency { get; }
+    public int TickRate { get; }
 
     public int? StageOverride { get; set; }
 

--- a/SlopCrew.API/ISlopCrewAPI.cs
+++ b/SlopCrew.API/ISlopCrewAPI.cs
@@ -12,6 +12,7 @@ public interface ISlopCrewAPI {
     public bool Connected { get; }
     public event Action OnConnected;
     public event Action OnDisconnected;
+    public ulong Latency { get; }
 
     public int? StageOverride { get; set; }
 
@@ -28,4 +29,5 @@ public interface ISlopCrewAPI {
 
     public event Action<uint, string, byte[]> OnCustomPacketReceived;
     public event Action<uint, string, byte[]> OnCustomCharacterInfoReceived;
+    public event Action<ulong> OnServerTickReceived;
 }

--- a/SlopCrew.Plugin/ConnectionManager.cs
+++ b/SlopCrew.Plugin/ConnectionManager.cs
@@ -171,6 +171,7 @@ public class ConnectionManager : IHostedService {
         switch (packet.MessageCase) {
             case ClientboundMessage.MessageOneofCase.Hello: {
                 this.TickRate = 1f / packet.Hello.TickRate;
+                this.api.ChangeTickRate(packet.Hello.TickRate);
                 break;
             }
 

--- a/SlopCrew.Plugin/ConnectionManager.cs
+++ b/SlopCrew.Plugin/ConnectionManager.cs
@@ -178,6 +178,8 @@ public class ConnectionManager : IHostedService {
                 var latency = (uint) (DateTime.Now - this.lastPing).TotalMilliseconds;
                 this.Latency = latency;
                 this.ServerTick = packet.Pong.Tick;
+                this.api.ChangeLatency(this.Latency);
+                this.api.DispatchServerTick(ServerTick);
                 break;
             }
 

--- a/SlopCrew.Plugin/SlopCrewAPI.cs
+++ b/SlopCrew.Plugin/SlopCrewAPI.cs
@@ -12,6 +12,7 @@ public class SlopCrewAPI : ISlopCrewAPI {
     public bool Connected { get; internal set; } = false;
     public event Action? OnConnected;
     public event Action? OnDisconnected;
+    public ulong Latency { get; internal set; } = 0;
 
     public int? StageOverride { get; set; }
 
@@ -68,6 +69,7 @@ public class SlopCrewAPI : ISlopCrewAPI {
 
     public event Action<uint, string, byte[]>? OnCustomPacketReceived;
     public event Action<uint, string, byte[]>? OnCustomCharacterInfoReceived;
+    public event Action<ulong>? OnServerTickReceived;
 
     internal void ChangeConnected(bool value) {
         if (this.Connected == value) return;
@@ -79,6 +81,10 @@ public class SlopCrewAPI : ISlopCrewAPI {
             this.OnDisconnected?.Invoke();
         }
     }
+    
+    internal void ChangeLatency(ulong latency) {
+        this.Latency = latency;
+    }
 
     internal void ChangePlayerCount(int count) {
         this.PlayerCount = count;
@@ -87,5 +93,9 @@ public class SlopCrewAPI : ISlopCrewAPI {
 
     internal void DispatchCustomPacket(uint player, string id, byte[] data) {
         this.OnCustomPacketReceived?.Invoke(player, id, data);
+    }
+    
+    internal void DispatchServerTick(ulong tick) {
+        this.OnServerTickReceived?.Invoke(tick);
     }
 }

--- a/SlopCrew.Plugin/SlopCrewAPI.cs
+++ b/SlopCrew.Plugin/SlopCrewAPI.cs
@@ -13,6 +13,7 @@ public class SlopCrewAPI : ISlopCrewAPI {
     public event Action? OnConnected;
     public event Action? OnDisconnected;
     public ulong Latency { get; internal set; } = 0;
+    public int TickRate { get; internal set; } = 0;
 
     public int? StageOverride { get; set; }
 
@@ -84,6 +85,10 @@ public class SlopCrewAPI : ISlopCrewAPI {
     
     internal void ChangeLatency(ulong latency) {
         this.Latency = latency;
+    }
+    
+    internal void ChangeTickRate(int tickRate) {
+        this.TickRate = tickRate;
     }
 
     internal void ChangePlayerCount(int count) {

--- a/SlopCrew.Server/Network/NetworkService.cs
+++ b/SlopCrew.Server/Network/NetworkService.cs
@@ -178,6 +178,8 @@ public class NetworkService : BackgroundService {
 
     public void Disconnect(uint connection) {
         this.server!.CloseConnection(connection);
+        this.clients.Remove(connection);
+        this.metricsService.UpdateConnections(this.clients.Count);
     }
 
     public void SendPacket(uint connection, ClientboundMessage packet, SendFlags flags = SendFlags.Reliable) {


### PR DESCRIPTION
This PR exposes additional information in `ISlopCrewAPI` so that animations in custom maps can synchronize themselves between all clients.

The idea is that a mod can `ServerTick % AnimationLengthInTicks` to know where to put animation playback.  It can slightly slow down or speed up playback to account for any clock drift.

The code changes are:

- Adjust `TickRateService` to avoid clock drift regardless of the time spent executing `RunTick()`
- Add an event invoked every time the client receives a new `ServerTick` from a `Pong`
- Expose client's estimated round-trip latency

I used a `Channel` in `TickRateService` because I was already familiar with channels as a way to sync things across threads.  It might not be the best tool for the job, but it was easy for me to reason about.  As I understand it, `Timer` can call `Elapsed` on any thread, but `await` ensures that the tick loop stays on the same thread.