### PR TITLE
Give unique names to Player GameObjects.

### DIFF
--- a/SlopCrew.Plugin/AssociatedPlayer.cs
+++ b/SlopCrew.Plugin/AssociatedPlayer.cs
@@ -63,6 +63,8 @@ public class AssociatedPlayer : IDisposable {
             moveStyle
         );
 
+        this.ReptilePlayer.gameObject.name = $"SlopCrew Player {this.SlopPlayer.Id}";
+
         this.ReptilePlayer.motor.gravity = 0;
         this.ReptilePlayer.motor.SetKinematic(true);
         this.ReptilePlayer.motor.enabled = false;


### PR DESCRIPTION
This one-liner fixes an oversight where multiple players could have the same GameObject name. 

Normally this wouldn't be an issue, but the SlopCrew API utilizes GameObject paths to retrieve players by their ID and viceversa, which could give wrong results as players could share the same GameObject name.